### PR TITLE
Update reclist version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ snowflake-connector-python==2.7.4
 python-dotenv==0.19.2
 comet-ml==3.26.0
 sagemaker==2.59.8
-reclist==0.2.3
+reclist==0.3.1
 dbt-snowflake==1.0.0
 tensorflow==2.8.0


### PR DESCRIPTION
The old version of reclist - that this repo depends on - is no longer installable in a clean virtual env. It depends on some very old packages that don't comply with current PEP standards.